### PR TITLE
Fixed a reference error of toast wrapper

### DIFF
--- a/src/Theme/index.tsx
+++ b/src/Theme/index.tsx
@@ -356,7 +356,7 @@ export class Theme extends React.Component<ThemeProps, ThemeState> {
   }
 
   updateToast = (toastID: number, toast: React.ReactNode) => {
-    this.toastWrapper.updateToast(toastID, toast);
+    this.toastWrapper && this.toastWrapper.updateToast(toastID, toast);
   }
 
   deleteToast = (toastID: number) => {


### PR DESCRIPTION
I have met a bad case about lifecycle when `Toast` component working with `Redirect` component of the lib *react-router*. 
With the switch of the route, the `toastWrapper` of `theme` has gone, but the lifecycle still not stopped. So I suggest to check this wrapper if it is exists to prevent throwing errors.