### PR TITLE
fix ReferenceError on server side renderng

### DIFF
--- a/src/common/electron/IS_ELECTRON_ENV.ts
+++ b/src/common/electron/IS_ELECTRON_ENV.ts
@@ -1,4 +1,4 @@
-const userAgent = navigator.userAgent.toLowerCase();
+const userAgent = typeof navigator === "undefined" ? "" : navigator.userAgent.toLowerCase();
 const isElectronEnv = userAgent.includes(" electron/");
 
 export default isElectronEnv;


### PR DESCRIPTION
![crash](https://user-images.githubusercontent.com/6937551/42868477-6be711b0-8aad-11e8-942f-652cb2583d63.png)

fix ReferenceError on runtime check

if runtime is node(not Electron or browser), ReferenceError will be thrown caused by undefined navigator object on `IS_ELECTRON_ENV.ts`