### PR TITLE
Fix NavigationView.autoResize

### DIFF
--- a/src/NavigationView/index.tsx
+++ b/src/NavigationView/index.tsx
@@ -152,7 +152,7 @@ export class NavigationView extends React.Component<NavigationViewProps, Navigat
       if (this.state.currDisplayMode !== "compact") {
         this.setState({
           currDisplayMode: "compact",
-          currInitWidth: 0
+          currInitWidth: this.props.initWidth
         });
       }
     } else {

--- a/src/NavigationView/index.tsx
+++ b/src/NavigationView/index.tsx
@@ -148,7 +148,7 @@ export class NavigationView extends React.Component<NavigationViewProps, Navigat
   }
 
   autoResize = (e?: Event) => {
-    if (window.innerWidth < 1280) {
+    if (window.innerWidth >= 1280) {
       if (this.state.currDisplayMode !== "compact") {
         this.setState({
           currDisplayMode: "compact",


### PR DESCRIPTION
https://github.com/myxvisual/react-uwp/blob/096b8239b2b864db8658656a18a595d082becc32/src/NavigationView/index.tsx#L151

This piece of code seems wrong to me if used with this piece of code:

```javascript
<NavigationView
    pageTitle="Test"
    background="#FF0000"
    defaultExpanded={ true }
    expandedWidth={ 260 }
    isControlled={ true }
/>
```

it makes the `NavigationView` background disappear and first the remaining menu will overlay the content (until clicked / unfocused) and at the same time the whole layout is moved in the original place of the `NavigationView`. Or in other words, the logic seems inverted.

Also another issue is when the `currInitWidth: 0` is set because then these steps will remove the element completely from user's view and it can't be retrieved back without dev tools:

1. Load with 1280+ width
2. Resize to <1280
3. Resize back to 1280+

Also, unless either removed completely or replaced with original `props.initWidth` it'll just overwrite user's value which undesired.