### PR TITLE
fix: Do not toggle NavigationView with boolean

### DIFF
--- a/src/NavigationView/index.tsx
+++ b/src/NavigationView/index.tsx
@@ -172,8 +172,10 @@ export class NavigationView extends React.Component<NavigationViewProps, Navigat
   }
 
   toggleExpanded = (expanded?: boolean) => {
-    if (typeof expanded === "boolean" && expanded !== this.state.expanded) {
-      this.setState({ expanded });
+    if (typeof expanded === "boolean") {
+      if (expanded !== this.state.expanded) {
+        this.setState({ expanded });
+      }
     } else {
       this.setState((prevState, prevProps) => ({  expanded: !prevState.expanded }));
     }


### PR DESCRIPTION
If a boolean is used for the toggleExpanded function and the variable is the same as the current state (i.e. telling the NavigationView to close when it is already closed, or open when it is already open), the NavigationView would have toggled it's state in the past.
This (hopefully) fixes this issue.